### PR TITLE
[FEAT]: Se añadió la configuración del interceptor para administrar el JWT

### DIFF
--- a/.idea/appInsightsSettings.xml
+++ b/.idea/appInsightsSettings.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AppInsightsSettings">
+    <option name="tabSettings">
+      <map>
+        <entry key="Firebase Crashlytics">
+          <value>
+            <InsightsFilterSettings>
+              <option name="connection">
+                <ConnectionSetting>
+                  <option name="appId" value="PLACEHOLDER" />
+                  <option name="mobileSdkAppId" value="" />
+                  <option name="projectId" value="" />
+                  <option name="projectNumber" value="" />
+                </ConnectionSetting>
+              </option>
+              <option name="signal" value="SIGNAL_UNSPECIFIED" />
+              <option name="timeIntervalDays" value="THIRTY_DAYS" />
+              <option name="visibilityType" value="ALL" />
+            </InsightsFilterSettings>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/app/src/main/java/com/uriel/musicjam/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/uriel/musicjam/core/di/NetworkModule.kt
@@ -1,0 +1,35 @@
+package com.uriel.musicjam.core.di
+
+import com.uriel.musicjam.core.interceptors.AuthInterceptor
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+
+    // Se crea un cliente http para administrar el interceptor
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(authInterceptor: AuthInterceptor): OkHttpClient {
+        return OkHttpClient.Builder()
+            .addInterceptor(authInterceptor)
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl("https://spority.aleosh.online/")
+            .client(okHttpClient)  // <-- agregamos el cliente http que contiene el interceptor
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+    }
+}

--- a/app/src/main/java/com/uriel/musicjam/core/interceptors/AuthInterceptor.kt
+++ b/app/src/main/java/com/uriel/musicjam/core/interceptors/AuthInterceptor.kt
@@ -1,0 +1,27 @@
+package com.uriel.musicjam.core.interceptors
+
+import com.uriel.musicjam.core.storage.TokenManager
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+
+class AuthInterceptor @Inject constructor (
+    private val tokenManager: TokenManager
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val originalRequest = chain.request()
+        val token = tokenManager.getToken()
+
+        // Si no hay token, hacemos la petición normal (ej. Login/Register)
+        if (token == null) {
+            return chain.proceed(originalRequest)
+        }
+
+        // Si hay token, creamos una nueva petición con el header
+        val newRequest = originalRequest.newBuilder()
+            .addHeader("Authorization", "Bearer $token")
+            .build()
+
+        return chain.proceed(newRequest)
+    }
+}

--- a/app/src/main/java/com/uriel/musicjam/core/storage/TokenManager.kt
+++ b/app/src/main/java/com/uriel/musicjam/core/storage/TokenManager.kt
@@ -1,0 +1,29 @@
+package com.uriel.musicjam.core.storage
+
+import android.content.Context
+import android.content.SharedPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+class TokenManager @Inject constructor(@ApplicationContext context: Context) {
+    private val prefs: SharedPreferences = context.getSharedPreferences("auth_prefs", Context.MODE_PRIVATE)
+
+    companion object {
+        private const val USER_TOKEN = "user_token"
+    }
+
+    // Guardar token
+    fun saveToken(token: String) {
+        prefs.edit().putString(USER_TOKEN, token).apply()
+    }
+
+    // Obtener token
+    fun getToken(): String? {
+        return prefs.getString(USER_TOKEN, null)
+    }
+
+    // Borrar token (Logout)
+    fun clearToken() {
+        prefs.edit().remove(USER_TOKEN).apply()
+    }
+}


### PR DESCRIPTION
Se crearon estos packages:
- storage: Guarda el token en memoria local, permite escribir, leer y eliminar
- interceptors: Guarda la lógica de los interceptors que existan, en este caso el AuthInterceptor encargado de la gestión del JWT
- di: En NetworkModule se gestionó el instanciamiento de un cliente http que provee el interceptor y lo añade a la instancia de retrofit.